### PR TITLE
Fix relative file paths plus sequence_models and ESM dependency issues

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "baselines/esm"]
 	path = baselines/esm
 	url = git@github.com:facebookresearch/esm.git
+	branch = v0.4.2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "baselines/esm"]
+	path = baselines/esm
+	url = git@github.com:facebookresearch/esm.git

--- a/baselines/README.md
+++ b/baselines/README.md
@@ -24,7 +24,7 @@ Further details about our baselines are below:
 
 ## ESM (Evolutionary Scale Modeling) Embedding
 
-All datasets need to first be embedded using the appropriate ESM model (ESM-1b, ESM-1v, ESM-untrained). We provide a script, `embeddings.py`, that 1) performs bulk ESM embeddings using pretrained models and 2) saves concatenated PyTorch tensors for train, test, and validation splits. More information on ESM embeddings can be found at the original [ESM repo](https://github.com/facebookresearch/esm).
+All datasets need to first be embedded using the appropriate ESM model (ESM-1b, ESM-1v, ESM-untrained). We provide a script, `embeddings.py`, that 1) performs bulk ESM embeddings using pretrained models and 2) saves concatenated PyTorch tensors for train, test, and validation splits. More information on ESM embeddings can be found at the original [ESM repo](https://github.com/facebookresearch/esm). The ESM repo is included as a submodule of this repo, so you can use `git submodule update --init` to populate the `esm` submodule (if you didn't use the `--recurse-submodules` argument when cloning this repo).
 
 Once embedded and saved in `.pt` format, ESM models can be run using the `train_all.py` script. For example, the following command trains the des-mut AAV split on ESM-1b using GPU 3:
  ```$ python train_all.py aav_1 esm1b 3```

--- a/baselines/baselines_environment.yml
+++ b/baselines/baselines_environment.yml
@@ -178,7 +178,7 @@ dependencies:
   - pip:
     - biopython==1.79
     - debugpy==1.4.1
-    - fair-esm==0.4.0
+    - fair-esm==0.4.2
     - ipykernel==6.0.3
     - joblib==1.0.1
     - matplotlib==3.4.2

--- a/baselines/baselines_environment.yml
+++ b/baselines/baselines_environment.yml
@@ -21,6 +21,8 @@ dependencies:
   - blas=1.0=mkl
   - bleach=3.3.0=pyh44b312d_0
   - bokeh=2.3.3=py39h06a4308_0
+  - bottleneck=1.3.4=py39hce1f21e_0
+  - brotli=1.0.9=he6710b0_2
   - brotlipy=0.7.0=py39h3811e60_1001
   - bzip2=1.0.8=h7b6447c_0
   - ca-certificates=2021.5.30=ha878542_0
@@ -40,6 +42,7 @@ dependencies:
   - ffmpeg=4.3=hf484d3e_0
   - firefox=90.0=h9c3ff4c_0
   - fontconfig=2.13.0=h9420a91_0
+  - fonttools=4.25.0=pyhd3eb1b0_0
   - freetype=2.10.4=h5ab3b9f_0
   - geckodriver=0.29.1=h3146498_0
   - glib=2.56.2=hd408876_0
@@ -94,6 +97,7 @@ dependencies:
   - mkl-service=2.3.0=py39h27cfd23_1
   - mkl_fft=1.3.0=py39h42c9631_2
   - mkl_random=1.2.1=py39ha9443f7_2
+  - munkres=1.1.4=py_0
   - nbclassic=0.3.1=pyhd8ed1ab_1
   - nbclient=0.5.3=pyhd8ed1ab_0
   - nbconvert=6.1.0=py39hf3d152e_0
@@ -103,6 +107,7 @@ dependencies:
   - nettle=3.7.3=hbbd107a_1
   - ninja=1.10.2=hff7bd54_1
   - notebook=6.4.0=pyha770c72_0
+  - numexpr=2.7.3=py39h22e1b3c_1
   - olefile=0.46=py_0
   - openh264=2.1.0=hd408876_0
   - openssl=1.1.1k=h7f98852_0
@@ -182,5 +187,6 @@ dependencies:
     - python-levenshtein==0.12.2
     - scikit-learn==0.24.2
     - scipy==1.7.0
+    - sequence-models==1.0.0
     - threadpoolctl==2.1.0
 

--- a/baselines/embeddings/embeddings.py
+++ b/baselines/embeddings/embeddings.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import argparse 
 
-sys.path.append('/../../FLIP/baselines/')
+sys.path.append('../../FLIP/baselines/')
 from utils import load_dataset
 from train_all import split_dict
 
@@ -106,14 +106,14 @@ def main(args):
         print('sending command line arguments')
 
         if args.truncate:
-            os.system('python /.../esm/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'train.fasta') + ' ' + str(PATH / 'train') + ' ' + '--repr_layers 33 --include mean per_tok --truncate --gpu '+args.gpu)
-            os.system('python /.../esm/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'test.fasta') + ' ' + str(PATH / 'test') + ' ' + '--repr_layers 33 --include mean per_tok --truncate --gpu '+args.gpu)
-            os.system('python /.../esm/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'val.fasta') + ' ' + str(PATH / 'val') + ' ' + '--repr_layers 33 --include mean per_tok --truncate --gpu '+args.gpu)
+            os.system('python ../../esm/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'train.fasta') + ' ' + str(PATH / 'train') + ' ' + '--repr_layers 33 --include mean per_tok --truncate')
+            os.system('python ../../esm/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'test.fasta') + ' ' + str(PATH / 'test') + ' ' + '--repr_layers 33 --include mean per_tok --truncate')
+            os.system('python ../../esm/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'val.fasta') + ' ' + str(PATH / 'val') + ' ' + '--repr_layers 33 --include mean per_tok --truncate')
 
         else:
-            os.system('python /.../esm/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'train.fasta') + ' ' + str(PATH / 'train') + ' ' + '--repr_layers 33 --include mean per_tok --gpu '+args.gpu)
-            os.system('python /.../esm/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'test.fasta') + ' ' + str(PATH / 'test') + ' ' + '--repr_layers 33 --include mean per_tok --gpu '+args.gpu)
-            os.system('python /.../esm/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'val.fasta') + ' ' + str(PATH / 'val') + ' ' + '--repr_layers 33 --include mean per_tok --gpu '+args.gpu)
+            os.system('python ../../esm/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'train.fasta') + ' ' + str(PATH / 'train') + ' ' + '--repr_layers 33 --include mean per_tok')
+            os.system('python ../../esm/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'test.fasta') + ' ' + str(PATH / 'test') + ' ' + '--repr_layers 33 --include mean per_tok')
+            os.system('python ../../esm/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'val.fasta') + ' ' + str(PATH / 'val') + ' ' + '--repr_layers 33 --include mean per_tok')
     
     if args.concat_tensors:
         print('making empty tensors for train set')

--- a/baselines/embeddings/embeddings.py
+++ b/baselines/embeddings/embeddings.py
@@ -106,15 +106,18 @@ def main(args):
         print('sending command line arguments')
 
         if args.truncate:
-            os.system('python ../../esm/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'train.fasta') + ' ' + str(PATH / 'train') + ' ' + '--repr_layers 33 --include mean per_tok --truncate')
-            os.system('python ../../esm/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'test.fasta') + ' ' + str(PATH / 'test') + ' ' + '--repr_layers 33 --include mean per_tok --truncate')
-            os.system('python ../../esm/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'val.fasta') + ' ' + str(PATH / 'val') + ' ' + '--repr_layers 33 --include mean per_tok --truncate')
+            exit_code = os.system('python esm/scripts/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'train.fasta') + ' ' + str(PATH / 'train') + ' ' + '--repr_layers 33 --include mean per_tok --truncate')
+            os.system('python esm/scripts/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'test.fasta') + ' ' + str(PATH / 'test') + ' ' + '--repr_layers 33 --include mean per_tok --truncate')
+            os.system('python esm/scripts/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'val.fasta') + ' ' + str(PATH / 'val') + ' ' + '--repr_layers 33 --include mean per_tok --truncate')
 
         else:
-            os.system('python ../../esm/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'train.fasta') + ' ' + str(PATH / 'train') + ' ' + '--repr_layers 33 --include mean per_tok')
-            os.system('python ../../esm/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'test.fasta') + ' ' + str(PATH / 'test') + ' ' + '--repr_layers 33 --include mean per_tok')
-            os.system('python ../../esm/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'val.fasta') + ' ' + str(PATH / 'val') + ' ' + '--repr_layers 33 --include mean per_tok')
-    
+            exit_code = os.system('python esm/scripts/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'train.fasta') + ' ' + str(PATH / 'train') + ' ' + '--repr_layers 33 --include mean per_tok')
+            os.system('python esm/scripts/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'test.fasta') + ' ' + str(PATH / 'test') + ' ' + '--repr_layers 33 --include mean per_tok')
+            os.system('python esm/scripts/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'val.fasta') + ' ' + str(PATH / 'val') + ' ' + '--repr_layers 33 --include mean per_tok')
+        
+        if exit_code != 0:
+            raise FileNotFoundError("Have you run `git submodule update --init` to populate the `esm` submodule?")
+
     if args.concat_tensors:
         print('making empty tensors for train set')
         # train set

--- a/baselines/embeddings/embeddings.py
+++ b/baselines/embeddings/embeddings.py
@@ -66,6 +66,11 @@ def create_parser():
         action="store_true"
     )
 
+    parser.add_argument(
+        "--local_esm_model",
+        action="store_true"
+    )
+
 
     return parser
 
@@ -104,6 +109,9 @@ def main(args):
     
     if args.bulk_compute:
         print('sending command line arguments')
+
+        if args.local_esm_model:
+            esm_dict[args.esm_version] = esm_dict[args.esm_version]+'.pt'
 
         if args.truncate:
             exit_code = os.system('python esm/scripts/extract.py ' + esm_dict[args.esm_version] + ' ' + str(PATH / 'train.fasta') + ' ' + str(PATH / 'train') + ' ' + '--repr_layers 33 --include mean per_tok --truncate')

--- a/baselines/filepaths.py
+++ b/baselines/filepaths.py
@@ -1,10 +1,10 @@
 
-HOME_DIR = '.../FLIP/' #FLIP home directory
+HOME_DIR = '../../FLIP/' #FLIP home directory
 BASELINE_DIR = HOME_DIR + 'baselines/'
 DATA_DIR = HOME_DIR + 'splits/'
 
-EMBEDDING_DIR = '.../embeddings/'
-RESULTS_DIR = '.../FLIP_results/'
+EMBEDDING_DIR = 'embeddings/'
+RESULTS_DIR = '../FLIP_results/'
 
-SEQ_MODELS = '.../sequence_models' #link to sequence_paths submodule
+SEQ_MODELS = '../sequence_models' #link to sequence_paths submodule
 


### PR DESCRIPTION
I'm suggesting a few fixes to issues I came across while trying to run the `baselines/embeddings/embeddings.py` script:

- relative file paths: several file paths were incorrect
- `sequence_models` not listed as required package in baselines environment yaml file ( #8 )
- the ESM `extract.py` script is used in `embeddings.py`, so I made ESM a submodule of FLIP and included a reminder message to the user to init/update the submodule if they get a `FileNotFoundError` while trying to execute that part of the script