### PR TITLE
Added means only option for embeddings of large datasets

### DIFF
--- a/baselines/embeddings/embeddings.py
+++ b/baselines/embeddings/embeddings.py
@@ -71,6 +71,10 @@ def create_parser():
         action="store_true"
     )
 
+    parser.add_argument(
+        "--means_only",
+        action="store_true"
+    )
 
     return parser
 
@@ -85,7 +89,7 @@ def main(args):
     train_len = len(train)
     max_length += 2
 
-    PATH = Path.cwd() / dataset / args.esm_version / split 
+    PATH = Path.cwd() / "embeddings" / dataset / args.esm_version / split 
     PATH.mkdir(parents=True, exist_ok=True)
 
     if args.make_fasta:
@@ -129,10 +133,11 @@ def main(args):
     if args.concat_tensors:
         print('making empty tensors for train set')
         # train set
-        if args.truncate:
-            embs_aa = torch.zeros([train_len, 1022, 1280])
-        else:
-            embs_aa = torch.zeros([train_len, max_length, 1280])
+        if not args.means_only:
+            if args.truncate:
+                embs_aa = torch.zeros([train_len, 1022, 1280])
+            else:
+                embs_aa = torch.zeros([train_len, max_length, 1280])
         embs_mean = torch.empty([train_len, 1280])
         labels = torch.empty([train_len])
 
@@ -141,21 +146,24 @@ def main(args):
         for l in tqdm(train.target):
             e = torch.load(PATH / 'train' / (str(i)+'.pt'))
             aa = e['representations'][33]
-            embs_aa[i, :aa.shape[0], :] = aa
+            if not args.means_only:
+                embs_aa[i, :aa.shape[0], :] = aa
             embs_mean[i] = e['mean_representations'][33]
             labels[i] = l
             i += 1
 
-        torch.save(embs_aa, PATH / 'train_aa.pt')
+        if not args.means_only:
+            torch.save(embs_aa, PATH / 'train_aa.pt')
         torch.save(embs_mean, PATH / 'train_mean.pt')
         torch.save(labels, PATH / 'train_labels.pt')
 
         print('making empty tensors for val set')
-        # train set
-        if args.truncate:
-            embs_aa = torch.zeros([val_len, 1022, 1280])
-        else:
-            embs_aa = torch.zeros([val_len, max_length, 1280])
+        # val set
+        if not args.means_only:
+            if args.truncate:
+                embs_aa = torch.zeros([val_len, 1022, 1280])
+            else:
+                embs_aa = torch.zeros([val_len, max_length, 1280])
         embs_mean = torch.empty([val_len, 1280])
         labels = torch.empty([val_len])
 
@@ -164,21 +172,24 @@ def main(args):
         for l in tqdm(val.target):
             e = torch.load(PATH / 'val' / (str(i)+'.pt'))
             aa = e['representations'][33]
-            embs_aa[i, :aa.shape[0], :] = aa
+            if not args.means_only:
+                embs_aa[i, :aa.shape[0], :] = aa
             embs_mean[i] = e['mean_representations'][33]
             labels[i] = l
             i += 1
 
-        torch.save(embs_aa, PATH / 'val_aa.pt')
+        if not args.means_only:
+            torch.save(embs_aa, PATH / 'val_aa.pt')
         torch.save(embs_mean, PATH / 'val_mean.pt')
         torch.save(labels, PATH / 'val_labels.pt')
         
         print('making empty tensors for test set')
         # test set
-        if args.truncate:
-            embs_aa = torch.zeros([test_len, 1022, 1280])
-        else:
-            embs_aa = torch.zeros([test_len, max_length, 1280])
+        if not args.means_only:
+            if args.truncate:
+                embs_aa = torch.zeros([test_len, 1022, 1280])
+            else:
+                embs_aa = torch.zeros([test_len, max_length, 1280])
         embs_mean = torch.empty([test_len, 1280])
         labels = torch.empty([test_len])
 
@@ -187,12 +198,14 @@ def main(args):
         for l in tqdm(test.target):
             e = torch.load(PATH /'test'/ (str(i)+'.pt'))
             aa = e['representations'][33]
-            embs_aa[i, :aa.shape[0], :] = aa
+            if not args.means_only:
+                embs_aa[i, :aa.shape[0], :] = aa
             embs_mean[i] = e['mean_representations'][33]
             labels[i] = l
             i += 1
             
-        torch.save(embs_aa, PATH / 'test_aa.pt')
+        if not args.means_only:
+            torch.save(embs_aa, PATH / 'test_aa.pt')
         torch.save(embs_mean, PATH / 'test_mean.pt')
         torch.save(labels, PATH / 'test_labels.pt')
 


### PR DESCRIPTION
I added a new argument to the embeddings script that allows a user to write only the mean embeddings to files. Some of the splits (e.g. AAV mut_des) may be too large to fit in memory for some users, so this gives the option to only write out the mean files during the tensor concatenation step.