### PR TITLE
Fixing broken links

### DIFF
--- a/splits/bind/README.md
+++ b/splits/bind/README.md
@@ -6,7 +6,7 @@ The six Bind splits stem from a [2021 publication](https://www.nature.com/articl
 
 The full dataset is divided in a development set and an independent set.The development set contains `all.fasta` with all information associated to proteins; `binding_residues_2.5_metal.txt`, `binding_residues_2.5_nuclear.txt` and `binding_residues_2.5_small.txt` with the binding residues for each protein ID; and `uniprot_test.txt` contains the IDs of the proteins for testing (set named TestSet300). The independent set contains the same files but with proteins originally selected only for testing (set named TestSetNew46).
 
-Due to the size of these files, they can be found at http://data.bioembeddings.com/public/FLIP/bind/.
+Due to the size of these files, they can be found at http://data.bioembeddings.com/public/FLIP/fasta/bind/.
 
 ### Legend 
 

--- a/splits/conservation/README.md
+++ b/splits/conservation/README.md
@@ -8,7 +8,7 @@ This is a well-known dataset and it is used to validate the behavior of code and
 
 The full dataset is divided in `seq_and_conservation.txt`, a FASTA file with 3 lines per entry: amino acid sequence, cotinuous conservation scores (ignored), conservation classes between 1 and 9 (1 = very variable, 9 = very conserved); `train_ids.txt`, IDs of the proteins for training (9392 proteins); `val_ids.txt`, IDs of the proteins for validation (555 proteins); and `test_ids.txt`, IDs of the proteins for testing (519 proteins).
 
-Due to the size of these files, they can be found at http://data.bioembeddings.com/public/FLIP/conservation/.
+Due to the size of these files, they can be found at http://data.bioembeddings.com/public/FLIP/fasta/conservation/.
 
 ### Splits
 

--- a/splits/sav/README.md
+++ b/splits/sav/README.md
@@ -6,7 +6,7 @@ The three SAV splits stem from a [2021 publication](https://link.springer.com/ar
 
 The full dataset is divided in one `sequences.fasta` file with all the wildtypes and different `.effect` files with the effect and neutral variants. The training/test folds are 9. Number 0 to 8 for testing and number 9 for testing.
 
-Due to the size of these files, they can be found at http://data.bioembeddings.com/public/FLIP/savs/.
+Due to the size of these files, they can be found at http://data.bioembeddings.com/public/FLIP/fasta/savs/.
 
 ### Splits
 

--- a/splits/scl/README.md
+++ b/splits/scl/README.md
@@ -10,7 +10,7 @@ The `deeploc_our_train_set.fasta`, `deeploc_our_val_set.fasta`, `deeploc_our_tes
 
 The `Swissprot_Train_Validation_dataset.csv` and the `hpa_testset.csv` are the training/validation and test set from the [DeepLoc v2 2022 publicaiton](https://academic.oup.com/nar/advance-article/doi/10.1093/nar/gkac278/6576357) used to create the DeepLoc 2.0 split.
 
-Due to the size of these files, they can be found at http://data.bioembeddings.com/public/FLIP/scl/.
+Due to the size of these files, they can be found at http://data.bioembeddings.com/public/FLIP/fasta/scl/.
 
 ### Splits
 

--- a/splits/secondary_structure/README.md
+++ b/splits/secondary_structure/README.md
@@ -8,7 +8,7 @@ This is a well-known dataset and it is used to validate the behavior of code and
 
 The full dataset is divided in `train.jsonl`, `val.jsonl` and `new_pisces.jsonl`, JSONL files with proteins for training, validation and testing. Each line is a sample with id, sequence, label and resolved. There are 9712 proteins for training, 1080 proteins for validation and 648 proteins for testing.
 
-Due to the size of these files, they can be found at http://data.bioembeddings.com/public/FLIP/secondary_structure/.
+Due to the size of these files, they can be found at http://data.bioembeddings.com/public/FLIP/fasta/secondary_structure/.
 
 ### Splits
 


### PR DESCRIPTION
Links to the split subdirectories (like [http://data.bioembeddings.com/public/FLIP/fasta/bind/](http://data.bioembeddings.com/public/FLIP/fasta/bind/)) where missing the /fasta/ subdirectory.

Furthermore, cloning is broken for me. Seems like the esm submodule causes the issue. Is this necessary at all? If not, I can include its removal in the pull request as well.