### PR TITLE
Correct typo in README of meltome dataset

### DIFF
--- a/splits/meltome/README.md
+++ b/splits/meltome/README.md
@@ -49,7 +49,7 @@ The cluster file `meltome_PIDE20_clusters.tsv` was used to create train/test spl
 
 ### Splits
 
-The train/test splits were computed by splitting the clusters. 80% of the clusters were used for training, while 20% were used for training.
+The train/test splits were computed by splitting the clusters. 80% of the clusters were used for training, while 20% were used for testing.
 
 Splits ([semaphore legend](../../README.md#split-semaphore)):
 - 🟢 `mixed`: uses cluster components for training and cluster representatives for testing (goal: avoid overestimaiting performance on big clusters in the test set)


### PR DESCRIPTION
Hi there,
I came across a description in the README of the meltome dataset that I believe to contain a small mistake.

The word "training" was used twice instead of "training" and "testing" when describing the split proportions. The text before correction read that a 80/20 split was made, but both splits were used for training.
In this PR I suggest 80% of the data was used for the train set and 20% for the test set.

Cheers